### PR TITLE
replace chalk with ansi-colors

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,6 @@ const render = (tasks, options) => {
 };
 
 class VerboseRenderer {
-
 	constructor(tasks, options) {
 		this._tasks = tasks;
 		this._options = Object.assign({

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,5 @@
 'use strict';
-const chalk = require('chalk');
+const colors = require('ansi-colors');
 const format = require('date-fns/format');
 
 exports.log = (options, output) => {
@@ -10,5 +10,5 @@ exports.log = (options, output) => {
 
 	const timestamp = format(new Date(), options.dateFormat);
 
-	console.log(chalk.dim(`[${timestamp}]`) + ` ${output}`);
+	console.log(colors.dim(`[${timestamp}]`) + ` ${output}`);
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "format"
   ],
   "dependencies": {
-    "chalk": "^1.1.3",
+    "ansi-colors": "^3.0.0",
     "cli-cursor": "^2.1.0",
     "date-fns": "^1.27.2",
     "figures": "^1.7.0"

--- a/test/fixtures/utils.js
+++ b/test/fixtures/utils.js
@@ -1,5 +1,4 @@
 'use strict';
-const fs = require('fs');
 const hookStd = require('hook-std');
 const stripAnsi = require('strip-ansi');
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,7 @@
 import {serial as test} from 'ava';
 import Listr from 'listr';
 import format from 'date-fns/format';
-import renderer from '../';
+import renderer from '..';
 import {testOutput} from './fixtures/utils';
 
 const date = format(new Date(), 'DD/MM/YYYY');
@@ -18,7 +18,6 @@ test('task succeeds', async t => {
 	});
 
 	testOutput(t, [
-		'',
 		`[${date}] foo [started]\n`,
 		`[${date}] foo [completed]\n`
 	]);
@@ -27,7 +26,7 @@ test('task succeeds', async t => {
 });
 
 test('task fails', async t => {
-	t.plan(5);
+	t.plan(4);
 
 	const list = new Listr([
 		{
@@ -40,7 +39,6 @@ test('task fails', async t => {
 	});
 
 	testOutput(t, [
-		'',
 		`[${date}] foo [started]\n`,
 		`[${date}] foo [failed]\n`,
 		`[${date}] → Hello World\n`
@@ -65,7 +63,6 @@ test('hide timestamp by setting dateFormat to false', async t => {
 	});
 
 	testOutput(t, [
-		'',
 		`foo [started]\n`,
 		`foo [completed]\n`
 	]);


### PR DESCRIPTION
This PR replaces `chalk` with [ansi-colors](https://github.com/doowb/ansi-colors).

`ansi-colors` doesn't have any dependencies and also has notable performance improves when loading and executing compared to `chalk`. See [the benchmarks](https://github.com/doowb/ansi-colors#performance) for more information.

The first commit fixes linting errors reported by `xo` and updates the tests to pass. This was done before replacing `chalk` to ensure my other changes wouldn't break anything.
