### PR TITLE
Add optional stream argument to render to

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,8 @@ class VerboseRenderer {
 	constructor(tasks, options) {
 		this._tasks = tasks;
 		this._options = Object.assign({
-			dateFormat: 'HH:mm:ss'
+			dateFormat: 'HH:mm:ss',
+			stream: process.stdout
 		}, options);
 	}
 
@@ -52,12 +53,12 @@ class VerboseRenderer {
 	}
 
 	render() {
-		cliCursor.hide();
+		cliCursor.hide(this._options.stream);
 		render(this._tasks, this._options);
 	}
 
 	end() {
-		cliCursor.show();
+		cliCursor.show(this._options.stream);
 	}
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,12 +3,13 @@ const chalk = require('chalk');
 const format = require('date-fns/format');
 
 exports.log = (options, output) => {
+	const logger = new console.Console(options.stream, options.stream);
 	if (options.dateFormat === false) {
-		console.log(output);
+		logger.log(`${output}`);
 		return;
 	}
 
 	const timestamp = format(new Date(), options.dateFormat);
 
-	console.log(chalk.dim(`[${timestamp}]`) + ` ${output}`);
+	logger.log(chalk.dim(`[${timestamp}]`) + ` ${output}`);
 };

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,12 @@ Default: `HH:mm:ss`
 
 Format of the rendered timestamp. Use the [date-fns string format](https://date-fns.org/docs/format). If `false` is passed in, the timestamp will be hidden.
 
+### stream
+
+Type: `stream.Writable` <br>
+Default: `process.stdout`
+
+The stream to render to.
 
 ## Related
 

--- a/test/fixtures/utils.js
+++ b/test/fixtures/utils.js
@@ -6,11 +6,14 @@ exports.testOutput = (t, expected) => {
 	t.plan(t._test.planCount || expected.length);
 	let i = 0;
 
-	const promise = hookStd(actual => {
-		t.is(stripAnsi(actual), `${expected[i++]}`);
+	const promise = hookStd.stdout(actual => {
+		const stripped = stripAnsi(actual);
+		if (stripped !== '') {
+			t.is(stripped, `${expected[i++]}`);
 
-		if (i === expected.length) {
-			promise.unhook();
+			if (i === expected.length) {
+				promise.unhook();
+			}
 		}
 	});
 };

--- a/test/test.js
+++ b/test/test.js
@@ -1,8 +1,8 @@
 import {serial as test} from 'ava';
 import Listr from 'listr';
 import format from 'date-fns/format';
-import {testOutput} from './fixtures/utils';
 import renderer from '..';
+import {testOutput} from './fixtures/utils';
 
 const date = format(new Date(), 'dd/MM/yyyy');
 


### PR DESCRIPTION
As mentioned in https://github.com/SamVerschueren/listr-update-renderer/pull/26, it makes sense to send human-readable and informational logging to `stderr` when designing a pipeable command. Those commands typically reserve `stdout` for data that could be sent to another command. This PR attempts to make this renderer useful in that scenario by adding an optional argument to send output to streams other than `process.stdout`, like `process.stderr`.